### PR TITLE
Solution to allow use of route caching in Modules

### DIFF
--- a/src/ModuleServiceProvider.php
+++ b/src/ModuleServiceProvider.php
@@ -15,16 +15,17 @@ class ModuleServiceProvider extends ServiceProvider {
 	public function boot() {
 
 		if(is_dir(app_path().'/Modules/')) {
-
 			$modules = config("modules.enable") ?: array_map('class_basename', $this->files->directories(app_path().'/Modules/'));
 			foreach($modules as $module)  {
-				
-				$routes = app_path().'/Modules/'.$module.'/routes.php';
+				// Allow routes to be cached
+				if (!$this->app->routesAreCached()) {
+					$routes = app_path() . '/Modules/' . $module . '/routes.php';
+					if($this->files->exists($routes)) include $routes;
+				}
 				$helper = app_path().'/Modules/'.$module.'/helper.php';
 				$views  = app_path().'/Modules/'.$module.'/Views';
 				$trans  = app_path().'/Modules/'.$module.'/Translations';
 
-				if($this->files->exists($routes)) include $routes;
 				if($this->files->exists($helper)) include $helper;
 				if($this->files->isDirectory($views)) $this->loadViewsFrom($views, $module);
 				if($this->files->isDirectory($trans)) $this->loadTranslationsFrom($trans, $module);


### PR DESCRIPTION
When trying the command "php artisan route:cache" I noticed that caching of modules app/modules/MyModule/routes.php didn't get included.
I added this code and it seem to work fine.