### PR TITLE
Declare #files property

### DIFF
--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -33,6 +33,13 @@ class MigrateMakeCommand extends BaseMigrateMakeCommand
     protected $description = 'Create a new migration file in a module';
 
     /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected Filesystem $files;    
+
+    /**
      * Create a new migration install command instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator


### PR DESCRIPTION
Fix the Creation of dynamic property ArtemSchander\L5Modular\Console\MigrateMakeCommand::$files is deprecated in PHP 8.2